### PR TITLE
make the dot representation have quoted node labels

### DIFF
--- a/core/src/main/scala/viz/package.scala
+++ b/core/src/main/scala/viz/package.scala
@@ -30,7 +30,7 @@ package object viz {
         if (sa == "") "" else s"\t$n$sa\n"
     }
     def se(edge: LEdge[N,B]) = edge match {
-      case LEdge(n1, n2, b) => s"\t$n1 -> $n2${sl(b)}\n"
+      case LEdge(n1, n2, b) => s"""\t"$n1" -> "$n2"${sl(b)}\n"""
     }
     val n = g.labNodes
     val e = g.labEdges


### PR DESCRIPTION
I would have just escaped the quotes in place, but that apparently is not a thing due to:
https://issues.scala-lang.org/browse/SI-6476

So, I changed it to triple quotes, which still works.

-- T